### PR TITLE
added transformational invariance to BroadGo's positional caching and command submission

### DIFF
--- a/broadgo.yaml
+++ b/broadgo.yaml
@@ -1,5 +1,5 @@
 executable: "E:/KataGo-1.8.0/katago.exe"
 configuration: "E:/KataGo-1.8.0/shallow.cfg"
 model: "E:/KataGo-1.8.0/g170e-b10c128-s1141046784-d204142634.bin.gz"
-analysisThreads: 80
+analysisThreads: 12
 searchThreads: 1

--- a/dlgo/goboard_fast.py
+++ b/dlgo/goboard_fast.py
@@ -395,3 +395,15 @@ class GameState():
             return self.next_player
         game_result = compute_game_result(self)
         return game_result.winner
+
+    # I (sadakatsu) added this so I can build a game only once, but then transform the moves later based upon what
+    # representation I prefer.
+    @property
+    def history(self):
+        moves = []
+        current = self
+        while current:
+            if current.last_move or current.previous_state:
+                moves.insert(0, current.last_move)
+            current = current.previous_state
+        return moves

--- a/main.py
+++ b/main.py
@@ -1,19 +1,26 @@
 from threading import Lock, Thread
-from typing import Optional, List
-import sys
+from typing import Callable, List, Optional, Dict
 import time
 import yaml
 
+from dlgo.gotypes import Point
 from dlgo.utils import coords_from_point
 from flask import Flask, request
 from flask_cors import CORS
 from flask_restful import Resource, Api
-from position import Position
+from position import Position, get_transformation, get_undo, translate_label_to_point
 from katago import KataGo, Response, LineType, Command
 
 app = Flask(__name__)
 api = Api(app)
 CORS(app)
+
+
+def point_to_label(point: Optional[Point]) -> str:
+    return 'pass' if not point else coords_from_point(point)
+
+
+policy_points = [Point(row, col) for row in range(19, 0, -1) for col in range(1, 20)]
 
 
 class KataGoExecution:
@@ -32,7 +39,7 @@ class KataGoExecution:
         self.visits = 0
 
         self.critical_section = Lock()
-        self.position_results = {}
+        self.position_results: Dict[str, Response] = {}
         self.query_to_positions = {}
         self.submitted = set()
 
@@ -99,9 +106,11 @@ class KataGoExecution:
         data = Position.from_json(position_json)
         game = data.game
 
-        command = data.command()
+        command, orientation = data.command()
         if command.id not in self.query_to_positions:
             commands: List[Command] = [command]
+
+            transformation = get_transformation(orientation)
 
             package = {}
             self.query_to_positions[command.id] = package
@@ -109,13 +118,21 @@ class KataGoExecution:
             for move in game.legal_moves():
                 if move.is_resign:
                     continue
-                c = data.command(move)
-                package['pass' if move.is_pass else coords_from_point(move.point)] = c.id
+                c, _ = data.command(move)
                 commands.append(c)
+
+                # NOTE: The game is in the orientation in which the server received the position.  All the analysis is
+                # being done from the canonical representation's orientation.  That means we need to transform the legal
+                # move before storing it in the package if we are to be able to correctly restore the analysis later!
+                if move.is_pass:
+                    move_label = 'pass'
+                else:
+                    move_label = coords_from_point(transformation(move.point))
+                package[move_label] = c.id
 
             self._write_commands(commands)
 
-        return command.id
+        return f'{command.id}_{orientation}'
 
     def _write_commands(self, commands: List[Command]):
         with self.critical_section:
@@ -128,21 +145,54 @@ class KataGoExecution:
                     self.submitted_count += 1
                     self.submitted.add(c.id)
 
-    def get_analysis_results(self, position_id: str):
+    def get_analysis_results(self, position_id: str, undo: Callable[[Optional[Point]], Optional[Point]]):
+        global policy_points
+
         if position_id not in self.query_to_positions:
             raise Exception(f'There is no stored query with ID {position_id}.')
+
+        def correct_label(canonical_label: str):
+            return point_to_label(
+                undo(
+                    translate_label_to_point(canonical_label)
+                )
+            )
 
         payload = {'complete': True, 'moves': 1, 'movesComplete': 0, 'analyses': {}, 'direct': None}
 
         if position_id in self.position_results:
-            payload['direct'] = self.position_results[position_id].to_dict()
+            position = self.position_results[position_id]
+            payload['direct'] = position.to_dict()
+
+            # We need to correct all the searched move and principal variation move labels to match the reference
+            # orientation.
+            for moveInfo in payload['direct']['moveInfos']:
+                moveInfo['move'] = correct_label(moveInfo['move'])
+                moveInfo['pv'] = [correct_label(x) for x in moveInfo['pv']]
+
+            # We need to reorder the policy values so they match the reference orientation.  KataGo's documentation
+            # states:
+            # > Values are in row-major order, starting at the top-left of the board (e.g. A19) and going to the bottom
+            # > right (e.g. T1). The last value in the array is the policy value for passing.
+            for i, original_point in enumerate(policy_points):
+                reference_point = undo(original_point)
+                index = (19 - reference_point.row) * 19 + (reference_point.col - 1)
+                payload['direct']['policy'][index] = position.policy[i]
+
             payload['movesComplete'] += 1
 
-        for k, v in self.query_to_positions[position_id].items():
+        for original_k, v in self.query_to_positions[position_id].items():
+            restored_k = correct_label(original_k)
+
             payload['moves'] += 1
             if v in self.position_results:
-                payload['analyses'][k] = self.position_results[v].rootInfo.to_dict()
+                payload['analyses'][restored_k] = self.position_results[v].rootInfo.to_dict()
+                payload['analyses'][restored_k]['id'] = self.position_results[v].id
                 payload['movesComplete'] += 1
+
+                # TODO: How can I make the included ID provide the correct transformation for the nested position?  I
+                #  cannot use the parent position's orientation directly, since subsequent move can lead to its own
+                #  unique canonical orientation.
 
         if payload['moves'] != payload['movesComplete']:
             payload['complete'] = False
@@ -177,12 +227,15 @@ class PositionResource(Resource):
         global katago_execution
         return katago_execution.get_stats(), 200
 
-    def _return_query_result(self, id):
+    def _return_query_result(self, id_orientation):
         global katago_execution
 
         try:
-            return katago_execution.get_analysis_results(id), 200
+            id = id_orientation[:-2]
+            undo = get_undo(int(id_orientation[-1]))
+            return katago_execution.get_analysis_results(id, undo), 200
         except Exception as e:
+            print(e)
             return str(e), 400
 
     def post(self):


### PR DESCRIPTION
Every position has either 1, 2, 4, or 8 combinations of rotating or mirroring the position that results in a position with identical meaning.  Adding transformational invariance to the already existing transposition capability means that far fewer positions need to be searched in the opening.  This feature is going to be vital for the deeper searching capability I hope to write since there are going to be a staggering variety of openings that can result in positions with the same meaning.